### PR TITLE
Remove old duplicates of class files

### DIFF
--- a/files/highpoint.psm1
+++ b/files/highpoint.psm1
@@ -1,0 +1,28 @@
+Function Remove-OlderDuplicates {
+    [CmdletBinding()]
+
+    Param (
+        [Parameter(
+            Mandatory = $True,
+            HelpMessage = "Please enter the Path"
+        )]
+        [String] ${Path}
+    )
+
+    Begin {
+        ${ComputerName} = (Get-WmiObject Win32_Computersystem).Name.toLower()
+    }
+
+    Process {
+        Write-Verbose "[${ComputerName}][Goal] Remove duplicates on path '${Path}'"
+        Try {
+            Get-ChildItem -Path "${Path}" | Group-Object {[String]$($_.FullName -Replace '[\d]','')} | ForEach-Object {
+                If ($_.Count -gt 1) { 
+                    $_.Group | Sort-Object -Property {[int64]$($_.FullName -Replace '[^\d]','')} | Select-Object -First 1
+                }
+            } | Remove-Item | Out-Null
+        } Catch {
+            Throw "Something went wrong during the deletion of old duplicates"
+        }
+    }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,16 @@ class highpoint (
           require   => [ Exec["Expand ${package} to ${pkgtemp}"] ],
         }
 
+        exec { "Delete Duplicate '${package}' classes" :
+          command   => "
+              ${file('highpoint/highpoint.psm1')}
+              Remove-OlderDuplicates -Path ${regsubst("\'${ps_config_home}/class/\'", '(/|\\\\)', '\\', 'G')}
+            ",
+          provider  => powershell,
+          logoutput => true,
+          require   => [ Exec["Deploy ${pkgtemp}/*/java/app/*"] ],
+        }
+
         exec { "Delete ${pkgtemp} Directory" :
           command   =>  Sensitive(@("EOT")),
               New-Item -Path ${regsubst("\'${::env_temp}/empty\'", '(/|\\\\)', '\\', 'G')} -Type Directory -Force


### PR DESCRIPTION
Highpoint erroneously including conflicting class file
versions and asks to manually remove older versions of
duplicates.  So adding logic to automate this process.

Signed-off-by: Andy Dorfman <umaritimus@users.noreply.github.com>